### PR TITLE
リポジトリフィールドを追加

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 name = "gpsd-json"
 version = "0.1.0"
 edition = "2024"
+repository = "https://github.com/Kato-emb/gpsd-json"
 keywords = ["gpsd", "parser", "json", "protocol"]
 categories = ["API bindings", "Data structures"]
 license = "BSD-2-Clause"


### PR DESCRIPTION
This pull request makes a small change to the `Cargo.toml` file by adding a `repository` field with the project's GitHub URL. This helps users and tooling easily locate the source code for the project.