### PR TITLE
カテゴリ名が不正だったため修正

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2024"
 repository = "https://github.com/Kato-emb/gpsd-json"
 keywords = ["gpsd", "parser", "json", "protocol"]
-categories = ["API bindings", "Data structures"]
+categories = ["api-bindings", "data-structures"]
 license = "BSD-2-Clause"
 
 readme = "README.md"


### PR DESCRIPTION
This pull request makes a small update to the `Cargo.toml` file, standardizing the formatting of category names to use lowercase and hyphens for consistency with Rust package conventions.